### PR TITLE
fixed livp_to_jpg.py Image.frombytes TypeError

### DIFF
--- a/livp_to_jpg.py
+++ b/livp_to_jpg.py
@@ -59,7 +59,7 @@ def livp_to_jpg(img_item,img_source,livp_to_jpg_dir):
     image = Image.frombytes(
         heif_file.mode,
         heif_file.size,
-        heif_file.data,
+        heif_file.data.tobytes(),
         "raw",
     )
 


### PR DESCRIPTION
Fixed a bug in the live_to_jpg.py code where the from bytes side expects to receive a read-only byte object, while the above code obtains a memoryview object, converting the memoryview to a read-only byte object, and then passing it on.